### PR TITLE
fix/ 마감순으로 공고 불러오기 고침, 공고 불러오기에서 likesCount 는 좋아요 수와 likedUsers 는 좋아요 누른 유저 id 로 수정

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -50,8 +50,6 @@ export class AppController {
             ? null
             : req.authResult.user
 
-        if (user) return res.redirect('/')
-
         return { components: 'jobposts', user: user }
     }
 }

--- a/src/public/css/common.css
+++ b/src/public/css/common.css
@@ -46,23 +46,32 @@ button .muted {
 }
 
 .card-title {
-    font-size: 25px;
+    font-size: 22px;
     font-weight: 600;
 }
 
 .card-text {
     color: rgb(69, 87, 117, 0.8);
     padding: 5px 0;
+    font-size: 15px;
 }
 
 .card-text img {
-    height: 35px;
+    height: 30px;
     padding-right: 3px;
 }
 
-.card-text.row {
+.card-text .row {
     display: flex;
     align-items: center;
+}
+
+.card-col {
+    display: flex;
+    align-items: center;
+    color: rgb(69, 87, 117, 0.8) !important;
+    padding: 5px 0;
+    font-size: 15px;
 }
 
 .card-text.companyName {
@@ -73,7 +82,7 @@ button .muted {
     max-height: 150px;
     max-width: fit-content;
     margin: auto;
-    padding: 10px 0;
+    padding: 10px;
     position: relative;
 }
 

--- a/src/public/css/jobposts.css
+++ b/src/public/css/jobposts.css
@@ -33,3 +33,15 @@
     right: 0;
     padding: 0 10px;
 }
+
+.filterButton {
+    border-radius: 50px;
+    width: auto;
+    --bs-btn-active-bg: rgb(240, 115, 61, 0.9) !important;
+    --bs-btn-hover-bg: rgb(240, 115, 61, 0.9) !important;
+    --bs-btn-hover-border-color: rgb(240, 115, 61, 0.9) !important;
+}
+
+.filterButton .active {
+    color: white
+}

--- a/src/views/jobposts.ejs
+++ b/src/views/jobposts.ejs
@@ -39,6 +39,17 @@
                         </div>
                     </div>
                 </div>
+                <div class="row">
+                    <p class="keyword-text">
+                        <span class="material-symbols-outlined">
+                            code_blocks
+                        </span>
+                        기술 스택
+                    </p>
+                </div>
+                <div id="stackList">
+
+                </div>
             </div>
         </div>
         <div class="col-8" id="mainContainer">
@@ -109,6 +120,7 @@
             url: `/api/jobpost/filter${url.search}`,
             async: false,
             success: function (response) {
+                console.log(response)
                 showJobposts(response)
             }
         })
@@ -118,7 +130,6 @@
             url: `/api/jobpost/addresses`,
             async: false,
             success: function (response) {
-                console.log(response)
                 const { addressUpper, addressLower } = response
                 for (let i = 0; i < addressUpper.length; i++) {
                     let tempHtml = `<li><a class="dropdown-item" onclick="$('#addressLowerDropDown > li').hide(); $('#addressLowerDropDown > li.${addressUpper[i].address_upper}').show()">${addressUpper[i].address_upper}</a>
@@ -145,6 +156,25 @@
             async: false,
             success: function (response) {
                 console.log(response)
+
+                let categories = []
+                let tempHtml = ``
+                for (let i = 0; i < response.length; i++) {
+                    if (!categories.includes(response[i].category)) {
+                        categories.push(response[i].category)
+                        tempHtml = `<div class="row">
+                                            <p class="keyword-text">
+                                                ${response[i].category}
+                                            </p>
+                                        </div>
+                                        <div class="row" id="${response[i].category}"></div>`
+
+                        $('#stackList').append(tempHtml)
+                    }
+
+                    tempHtml = `<button class="btn btn-outline-secondary filterButton" type="button" data-bs-toggle="button" onclick="appendStackQueryParameter($(this).hasClass('active'),'${response[i].stack}')">${response[i].stack}</button>`
+                    $(`#${response[i].category}`).append(tempHtml)
+                }
             }
         })
     })
@@ -182,27 +212,30 @@
                                                 </p>
                                                 <div class="card-text row">
                                                     <div class="col">
+                                                        <a class="card-col">
                                                         <span class="material-symbols-outlined">
                                                             work
                                                         </span>
                                                         신입
+                                                        </a>
                                                     </div>
                                                     <div class="col-8">
+                                                        <a class="card-col">
                                                         <span class="material-symbols-outlined">
                                                             location_on
                                                         </span>
                                                         ${addressUpper} ${addressLower}
+                                                        </a>
                                                     </div>
                                                     <div class="col-8">
+                                                        <a class="card-col">
                                                         <span class="material-symbols-outlined">
                                                             calendar_month
                                                         </span>
                                                         ${deadlineDtm}
+                                                        </a>
                                                     </div>
                                                 </div>
-                                                <p class="card-text">
-
-                                                </p>
                                                 <p class="card-text">
                                                     `
             if (stackImgUrlArr !== null) {
@@ -233,6 +266,37 @@
             }
         }
 
+        window.location.href = url.href
+    }
+
+    function appendStackQueryParameter(hasClassActive, stack) {
+        console.log(hasClassActive, stack)
+        let url = new URL(window.location.href)
+        let stackParam = url.searchParams.get('stack')
+
+        // hasClassActive = true => 버튼 선택
+        if (hasClassActive) {
+            // If there is no 'stack' query parameter
+            if (!stackParam) {
+                url.searchParams.append('stack', stack)
+            } else {
+                // If there is the 'stack' query parameter
+                stackParam += `,${stack}`
+                url.searchParams.set('stack', stackParam)
+            }
+        }
+
+        // hasClassActive = false => 버튼 선택 취소
+        if (!hasClassActive) {
+            const newStackParam = stackParam.split(',').filter((value, _i, _a) => { return value !== stack }).join(',')
+            if (newStackParam.length === 0) {
+                url.searchParams.delete('stack')
+            } else {
+                url.searchParams.set('stack', [newStackParam])
+            }
+        }
+
+        console.log(url)
         window.location.href = url.href
     }
 

--- a/src/views/main.ejs
+++ b/src/views/main.ejs
@@ -394,22 +394,28 @@
                                                 </p>
                                                 <div class="card-text row">
                                                     <div class="col">
+                                                        <a class="card-col">
                                                         <span class="material-symbols-outlined">
                                                             work
                                                         </span>
                                                         신입
+                                                        </a>
                                                     </div>
                                                     <div class="col-8">
+                                                        <a class="card-col">
                                                         <span class="material-symbols-outlined">
                                                             location_on
                                                         </span>
                                                         ${addressUpper} ${addressLower}
+                                                        </a>
                                                     </div>
                                                     <div class="col-8">
+                                                        <a class="card-col">
                                                         <span class="material-symbols-outlined">
                                                             calendar_month
                                                         </span>
                                                         ${deadlineDtm}
+                                                        </a>
                                                     </div>
                                                 </div>
                                                 <p class="card-text">


### PR DESCRIPTION
# PR 목적
- 마감순으로 공고 불러오기 고쳐짐
- `jobpost.repository` 안에 공고 불러오기 함수 `getFilteredJobposts()`에서 불러오는 칼럼 수정:
기존: likes 는 좋아요 수
수정: likesCount 는 좋아요 수와 likedUsers 는 좋아요 누른 유저 id가 `group_concat` 된 칼럼