### PR TITLE
Fix: 원티드 스크레이핑 함수에서 주소를 부르면서 오류나는 부분 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ lerna-debug.log*
 
 .env
 *.exe
+
+src/model

--- a/src/jobpost/scraper/jobpostWantedAxiosScraper.ts
+++ b/src/jobpost/scraper/jobpostWantedAxiosScraper.ts
@@ -42,14 +42,29 @@ export async function wantedScraper() {
                     let addressLower: string | null
                     let longitude: number | null
                     let latitude: number | null
+                    let addressDetail: {
+                        lat?: number
+                        lng?: number
+                        address?: string
+                    }
+                    let addressName: string
+                    let getAddressResult
 
                     if (address) {
-                        const addressDetail = address.geo_location.n_location
-                        const addressName = addressDetail.address
-                        const getAddressResult = await getAddress(
-                            addressName,
-                            process.env.KAKAO_KEY
-                        )
+                        if (address.geo_location) {
+                            addressDetail = address.geo_location.n_location
+                            addressName = addressDetail.address
+                            getAddressResult = await getAddress(
+                                addressName,
+                                process.env.KAKAO_KEY
+                            )
+                        } else {
+                            getAddressResult = await getAddress(
+                                address.full_location,
+                                process.env.KAKAO_KEY
+                            )
+                        }
+
                         originalAddress = address.full_location
                         addressUpper = getAddressResult.addressUpper
                         addressLower = getAddressResult.addressLower
@@ -187,8 +202,8 @@ export async function wantedScraper() {
                 `https://www.wanted.co.kr${nextLink}`
             )
 
-            // nextLink = nextPage.data.links.next
-            nextLink = null
+            nextLink = nextPage.data.links.next
+            // nextLink = null
 
             jobsList = nextPage.data.data
         }


### PR DESCRIPTION
# PR 목적
원티드 스크레이핑 `jobpostWantedAxiosScraper.ts` 에서 `address.geo_location`이 null일 경우 에러가 나는 부분 해결했습니다.