### PR TITLE
feat: 조회수 구현

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -125,9 +125,9 @@ export class AppController {
             ? null
             : req.authResult.user
 
-        // const view = await this.cacheService.getViewCount(jobpostId)
-        // console.log('조회수:' + view)
-        // this.cacheService.setViewCount(jobpostId, user.userId)
+        this.cacheService.setViewCount(jobpostId, user.userId)
+        const view = await this.cacheService.getViewCount(jobpostId)
+        console.log('조회수:' + view)
 
 
         return { components: 'detail', user: user, jobpostId }

--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -40,26 +40,23 @@ export class CacheService {
 	}
 
 	async getViewCount(jobpostId: number) {
-		// return await this.redisClient.hget('views', jobpostId.toString())
-		// return await this.redisClient.hlen('view,' + jobpostId.toString())
-		// return await this.redisClient.smembers('viewjobposts')
+		return await this.redisClient.hget('views', jobpostId.toString())
 	}
 
 	async setViewCount(jobpostId: number, userId: number) {
-		// let pipe = this.redisClient.pipeline()
-		// let count = await this.redisClient.getbit(jobpostId.toString(), userId)
-		// console.log('bitmap: ' + count)
-		// if (count != 1) {
-		// 	pipe.setbit(jobpostId.toString(), userId, 1).expire(jobpostId.toString(), 5)
-		// 	pipe.exec()
-		// 	await this.addCountOne(jobpostId)
-		// }
-		// pipe.hset('viewjobpost',
-		// 	jobpostId.toString(), 'jobpostId',
-		// 	userId.toString(), 'userId')
+		let pipe = this.redisClient.pipeline()
+		let count = await this.redisClient.getbit(jobpostId.toString(), userId)
+		if (count != 1) {
+			pipe.setbit(jobpostId.toString(), userId, 1).expire(jobpostId.toString(), 5)
+			pipe.exec()
+			await this.addCountOne(jobpostId)
+		}
 	}
 
 	async addCountOne(jobpostId: number) {
+		if (!jobpostId) {
+			return
+		}
 		let count = Number(await this.redisClient.hget('views', jobpostId.toString()))
 		if (count > 0) {
 			count += 1


### PR DESCRIPTION
# PR 목적

> 조회 구현

- 해당하는 글의 'jobpostId' bitmap (userId, 0 or 1) , 글 조회수를 담은 'views' hash (공고아이디, 조회수(default:1)) 
- 조회 만료 시간 5초로 설정(test용)
- 상세 페이지 들어갈 경우 해당 유저가 조회를 했는지 검사 (bitmap 조회)
- 5초가 지나면 해당 유저의 데이터가 없어서 bitmap을 다시 넣고 hash에 해당하는 글 조회수 증가
- 만료 시간 내에 다시 들어오면 조회수 증가가 안됨
