### PR TITLE
Fix: Ajax에서 async false 제거해서 속도 개선

### DIFF
--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -1,69 +1,75 @@
-import { Injectable } from '@nestjs/common';
-import { Redis } from 'ioredis';
-import { RedisService } from '@liaoliaots/nestjs-redis';
+import { Injectable } from '@nestjs/common'
+import { Redis } from 'ioredis'
+import { RedisService } from '@liaoliaots/nestjs-redis'
 import { JobpostRepository } from '../jobpost/jobpost.repository'
 
 @Injectable()
 export class CacheService {
-	private readonly redisClient: Redis
-	private readonly jobpostRepository: JobpostRepository
-	constructor(
-		private readonly redisService: RedisService
-	) {
-		this.redisClient = redisService.getClient();
-	}
+    private readonly redisClient: Redis
+    private readonly jobpostRepository: JobpostRepository
+    constructor(private readonly redisService: RedisService) {
+        this.redisClient = redisService.getClient()
+    }
 
-	async getLikedjobpost(jobpostId: number, userId: number) {
-		return await this.redisClient.srem('likedjobposts', jobpostId.toString() + ',' + userId.toString())
-	}
+    async getLikedjobpost(jobpostId: number, userId: number) {
+        return await this.redisClient.srem(
+            'likedjobposts',
+            jobpostId.toString() + ',' + userId.toString()
+        )
+    }
 
-	async setLikedjobpost(jobpostId: number, userId: number) {
-		await this.redisClient.sadd('likedjobposts',
-			jobpostId.toString() + ',' + userId.toString())
-	}
+    async setLikedjobpost(jobpostId: number, userId: number) {
+        await this.redisClient.sadd(
+            'likedjobposts',
+            jobpostId.toString() + ',' + userId.toString()
+        )
+    }
 
-	async getAllLikedjobpost() {
-		return await this.redisClient.smembers('likedjobposts')
-	}
+    async getAllLikedjobpost() {
+        return await this.redisClient.smembers('likedjobposts')
+    }
 
+    async saveRefreshToken(userId: number, token: string) {
+        await this.redisClient.set(userId.toString(), token)
+    }
 
-	async saveRefreshToken(userId: number, token: string) {
-		await this.redisClient.set(userId.toString(), token)
-	}
+    async getRefreshToken(userId: number): Promise<string> {
+        return await this.redisClient.get(userId.toString())
+    }
 
-	async getRefreshToken(userId: number): Promise<string> {
-		return await this.redisClient.get(userId.toString())
-	}
+    async removeRedisRefreshToken(userId: number) {
+        return this.redisClient.del(userId.toString())
+    }
 
-	async removeRedisRefreshToken(userId: number) {
-		return this.redisClient.del(userId.toString())
-	}
+    async getViewCount(jobpostId: number) {
+        // return await this.redisClient.hget('views', jobpostId.toString())
+        // return await this.redisClient.hlen('view,' + jobpostId.toString())
+        // return await this.redisClient.smembers('viewjobposts')
+    }
 
-	async getViewCount(jobpostId: number) {
-		return await this.redisClient.hget('views', jobpostId.toString())
-	}
+    async setViewCount(jobpostId: number, userId: number) {
+        // let pipe = this.redisClient.pipeline()
+        // let count = await this.redisClient.getbit(jobpostId.toString(), userId)
+        // console.log('bitmap: ' + count)
+        // if (count != 1) {
+        // 	pipe.setbit(jobpostId.toString(), userId, 1).expire(jobpostId.toString(), 5)
+        // 	pipe.exec()
+        // 	await this.addCountOne(jobpostId)
+        // }
+        // pipe.hset('viewjobpost',
+        // 	jobpostId.toString(), 'jobpostId',
+        // 	userId.toString(), 'userId')
+    }
 
-	async setViewCount(jobpostId: number, userId: number) {
-		let pipe = this.redisClient.pipeline()
-		let count = await this.redisClient.getbit(jobpostId.toString(), userId)
-		if (count != 1) {
-			pipe.setbit(jobpostId.toString(), userId, 1).expire(jobpostId.toString(), 5)
-			pipe.exec()
-			await this.addCountOne(jobpostId)
-		}
-	}
-
-	async addCountOne(jobpostId: number) {
-		if (!jobpostId) {
-			return
-		}
-		let count = Number(await this.redisClient.hget('views', jobpostId.toString()))
-		if (count > 0) {
-			count += 1
-			await this.redisClient.hset('views', jobpostId.toString(), count)
-		} else {
-			await this.redisClient.hset('views', jobpostId.toString(), 1)
-		}
-	}
-
+    async addCountOne(jobpostId: number) {
+        let count = Number(
+            await this.redisClient.hget('views', jobpostId.toString())
+        )
+        if (count > 0) {
+            count += 1
+            await this.redisClient.hset('views', jobpostId.toString(), count)
+        } else {
+            await this.redisClient.hset('views', jobpostId.toString(), 1)
+        }
+    }
 }

--- a/src/jobpost/jobpost.service.ts
+++ b/src/jobpost/jobpost.service.ts
@@ -13,7 +13,7 @@ export class JobpostService {
         private companyRepository: CompanyRepository,
         private cacheService: CacheService,
         private logger: Logger
-    ) { }
+    ) {}
     async getSaraminJobposts() {
         const saraminScraper = new SaraminSelenium('100')
         const { companies, jobposts } = await saraminScraper.getSaraminScraper()

--- a/src/public/css/common.css
+++ b/src/public/css/common.css
@@ -86,6 +86,7 @@ button .muted {
     margin: auto;
     padding: 10px;
     position: relative;
+    object-fit: contain;
 }
 
 .material-symbols-outlined {

--- a/src/views/jobposts.ejs
+++ b/src/views/jobposts.ejs
@@ -1,6 +1,5 @@
 <div class="container-fluid">
     <div class="row">
-        <div class="col-2"></div>
         <div class="col-2" id="keyword-card">
             <div class="card">
                 <div class="row">
@@ -158,7 +157,6 @@
         $.ajax({
             type: 'GET',
             url: `/api/jobpost/filter${url.search}`,
-            async: false,
             success: function (response) {
                 $('#searchCount').html(
                     `${response.totalCount}개의 공고를 찾았습니다`
@@ -171,7 +169,6 @@
         $.ajax({
             type: 'GET',
             url: `/api/jobpost/addresses`,
-            async: false,
             success: function (response) {
                 const { addressUpper, addressLower } = response
 
@@ -229,7 +226,6 @@
         $.ajax({
             type: 'GET',
             url: `/api/jobpost/stacks`,
-            async: false,
             success: function (response) {
                 let categories = []
                 let tempHtml = ``
@@ -264,7 +260,6 @@
         $.ajax({
             type: 'GET',
             url: `/api/jobpost/keywords`,
-            async: false,
             success: function (response) {
                 for (let i = 0; i < response.length; i++) {
                     const tempHtml = `<button class="btn btn-outline-secondary filterButton" id="keywordCode${response[i].keyword_code}" type="button" data-bs-toggle="button" onclick="appendKeywordQueryParameter($(this).hasClass('active'),'${response[i].keyword_code}')">${response[i].keyword}</button>`

--- a/src/views/jobposts.ejs
+++ b/src/views/jobposts.ejs
@@ -1,5 +1,6 @@
 <div class="container-fluid">
     <div class="row">
+        <div class="col-2"></div>
         <div class="col-2" id="keyword-card">
             <div class="card">
                 <div class="row">
@@ -279,7 +280,7 @@
             for (let i = 0; i < stacks.length; i++) {
                 const stack = stacks[i].replaceAll(/\s/g, '')
                 $(`#${stack}`).addClass('active')
-                let categoty = $(`#${stack}`)
+                let category = $(`#${stack}`)
                     .parent()
                     .attr('id')
                     .split('List')[1]
@@ -288,7 +289,7 @@
                     stacks[i],
                     'Stack',
                     $(`#${stack}`).text(),
-                    categoty
+                    category
                 )
             }
         }

--- a/src/views/main.ejs
+++ b/src/views/main.ejs
@@ -333,9 +333,7 @@
         $.ajax({
             type: "GET",
             url: '/api/jobpost/filter?sort=recent&order=desc&limit=12',
-            async: false,
             success: function (response) {
-                console.log(response)
                 showCarouselJobposts('carouselRecent', response.data, response.likedUser)
             }
         })
@@ -343,7 +341,6 @@
         $.ajax({
             type: "GET",
             url: '/api/jobpost/filter?sort=popular&order=desc&limit=12',
-            async: false,
             success: function (response) {
                 showCarouselJobposts('carouselPopular', response.data, response.likedUser)
             }
@@ -352,9 +349,7 @@
         $.ajax({
             type: "GET",
             url: '/api/jobpost/filter?sort=ending&order=asc&limit=12',
-            async: false,
             success: function (response) {
-                console.log(response)
                 showCarouselJobposts('carouselEnding', response.data, response.likedUser)
             }
         })

--- a/src/views/mylikes.ejs
+++ b/src/views/mylikes.ejs
@@ -1,9 +1,6 @@
 <div class="mypage-content-wrap">
     <div class="mypage-content-title">내 찜 목록</div>
-    <div
-        id="mypage-content-mylikes-wrap"
-        class="mypage-content-mylikes-wrap"
-    ></div>
+    <div id="mypage-content-mylikes-wrap" class="mypage-content-mylikes-wrap"></div>
 </div>
 
 <script>
@@ -23,7 +20,7 @@
                     <div class='mylikes-container'>
                         <div class='mylikes'>
                             <img class='mylikes-jobpost-img' src='${jobpost.originalImgUrl}' />
-                            <div class='mylikes-jobpost-title'>${jobpost.title}</div>
+                            <a href='/jobpost/${jobpost.jobpostId}'><div class='mylikes-jobpost-title'>${jobpost.title}</div></a>
                             <div class='mylikes-jobpost-company'>${jobpost.company.companyName}</div>
                         </div>    
                     </div>
@@ -33,5 +30,5 @@
             document.getElementById('mypage-content-mylikes-wrap').innerHTML =
                 jobpostsHtml
         })
-        .catch((err) => {})
+        .catch((err) => { })
 </script>


### PR DESCRIPTION
# PR 목적
- 프론트에서 Ajax로 불러오는 부분에서 `async: false`가 걸려있어서 불러오는 속도가 느렸습니다.

메인페이지:
수정 전
![image](https://user-images.githubusercontent.com/20327256/225849943-69774a8f-0568-454b-b39c-6c8a87edceac.png)

수정 후
![image](https://user-images.githubusercontent.com/20327256/225849964-e39aade4-5415-4fcb-a876-0260650d3b25.png)

전체 공고 페이지:
수정 전
![image](https://user-images.githubusercontent.com/20327256/225850019-7a697eb9-72d7-47a8-8d06-8101d2541e50.png)

수정 후
![image](https://user-images.githubusercontent.com/20327256/225850060-869f865b-abdf-43f9-8c5b-e9d813a51058.png)

- 카드 이미지에 비율 깨지는 현상 고쳤습니다
- 유저가 찜한 페이지 제목에 상세 페이지 a 태그 적용했습니다
- `cache.service` 파일은 수정 안 했고 prettier만 적용되었습니다.