### PR TITLE
Fix: 조회수 DB반영 안되는 문제 수정

### DIFF
--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -81,7 +81,7 @@ export class CacheService {
     }
 
     async addCountOne(jobpostId: number) {
-        let count = Number(this.getViewCount(jobpostId))
+        let count = Number(await this.getViewCount(jobpostId))
         if (count > 0) {
             await this.redisClient.hincrby('views', jobpostId.toString(), 1)
         } else {

--- a/src/entities/jobpost.entity.ts
+++ b/src/entities/jobpost.entity.ts
@@ -84,7 +84,7 @@ export class Jobpost {
     @Column('datetime', { nullable: true })
     deadlineDtm: Date | null
 
-    @Column('int', { nullable: true })
+    @Column('int', { nullable: true, default: 0 })
     views: number | null
 
     @Column({ type: 'varchar', length: 1000, nullable: true })

--- a/src/jobpost/jobpost.repository.ts
+++ b/src/jobpost/jobpost.repository.ts
@@ -809,7 +809,7 @@ export class JobpostRepository extends Repository<Jobpost> {
 
     async updateView(views: string) {
         const viewCounts = views.split('/').map((view: string) => {
-            const [id, count] = view.split(',')
+            const [id, count] = view.split(', ')
             return { jobpostId: parseInt(id), views: parseInt(count) }
         })
 


### PR DESCRIPTION
## PR 목적
조회수 DB 반영 안되는 문제 수정

## 변경 사항
* 현재 캐싱된 채용공고 조회수 데이터를 들고오는 getViewCount 함수를 비동기 처리
* Jobpost 엔티티의 views 컬럼 default 값을 0 으로 설정
* 캐싱된 채용공고 조회수 데이터 문자열을 구분하는 기준 수정