### PR TITLE
Refactor: 메인 페이지 최신 공고, 곧 마감하는공고 캐싱 적용

### DIFF
--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -88,4 +88,24 @@ export class CacheService {
             await this.redisClient.hset('views', jobpostId.toString(), 1)
         }
     }
+
+    // 메인화면 채용공고 12개 캐싱
+    async setMainJobposts(sort, mainJobposts) {
+        await this.redisClient.set(
+            `main-${sort}`,
+            JSON.stringify(mainJobposts),
+            'EX',
+            60 * 60 * 24
+        )
+    }
+
+    // 메인화면 채용공고 12개 가져오기
+    async getMainJobposts(sort) {
+        return await this.redisClient.get(`main-${sort}`)
+    }
+
+    // 메인화면 채용공고가 캐시에 존재하는지 확인
+    async isCachedMainJobposts(sort) {
+        return await this.redisClient.exists(`main-${sort}`)
+    }
 }

--- a/src/jobpost/jobpost.service.ts
+++ b/src/jobpost/jobpost.service.ts
@@ -81,6 +81,35 @@ export class JobpostService {
         const limitNum = parseInt(limit) || 16
         const offsetNum = parseInt(offset) || 0
 
+        // 메인화면 최신순, 마감순 12개 요청 일 때
+        if (['recent', 'ending'].includes(sort) && limit === '12') {
+            // 캐시에 존재하는지 확인
+            const isCached = await this.cacheService.isCachedMainJobposts(sort)
+
+            if (isCached) {
+                // 존재할 때
+                const mainJobposts = await this.cacheService.getMainJobposts(
+                    sort
+                )
+
+                return JSON.parse(mainJobposts)
+            } else {
+                // 존재하지 않을 떄 캐싱
+                const mainJobposts =
+                    await this.jobpostRepository.getFilteredJobposts(
+                        sort,
+                        order,
+                        limitNum,
+                        offsetNum,
+                        others
+                    )
+                // 메인화면 인기순 채용공고 12개 캐싱, 만료기간 하루
+                await this.cacheService.setMainJobposts(sort, mainJobposts)
+
+                return mainJobposts
+            }
+        }
+
         return await this.jobpostRepository.getRecommendedJobposts(
             sort,
             order,


### PR DESCRIPTION
## PR 목적
* 메인 페이지 최신공고, 곧 마감하는공고 캐싱 적용

## 변경 사항
* Cache Service - 채용공고 캐싱 함수 구현 
* Jobpost Service - 정렬 종류에 따라 캐싱 적용